### PR TITLE
fix(saga-retry): Opt-in pattern for retrying non-SpinnakerExceptions …

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/ExceptionClassifierConfigurationProperties.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/ExceptionClassifierConfigurationProperties.java
@@ -25,8 +25,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class ExceptionClassifierConfigurationProperties {
 
   /**
-   * A list of fully-qualified Exception class names that are not retryable within the scope of
+   * A list of fully-qualified Exception class names that are retryable within the scope of
    * Saga-backed orchestrations.
    */
-  private List<String> nonRetryableClasses = new ArrayList<>();
+  private List<String> retryableClasses = new ArrayList<>();
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/ExceptionClassifier.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/ExceptionClassifier.java
@@ -55,24 +55,24 @@ public class ExceptionClassifier {
 
     boolean retryable = false;
     try {
-      String dynamicNonRetryableClasses =
+      String dynamicRetraybleClasses =
           dynamicConfigService.getConfig(
               String.class,
-              "clouddriver.exceptionClassifier.nonRetryableExceptions",
-              String.join(",", properties.getNonRetryableClasses()));
+              "clouddriver.exception-classifier.retryable-exceptions",
+              String.join(",", properties.getRetryableClasses()));
 
-      if (dynamicNonRetryableClasses != null) {
-        List<String> dynamicNonRetryableClassesList =
-            Lists.newArrayList(Splitter.on(",").split(dynamicNonRetryableClasses));
+      if (dynamicRetraybleClasses != null) {
+        List<String> dynamicRetraybleClassesList =
+            Lists.newArrayList(Splitter.on(",").split(dynamicRetraybleClasses));
 
-        List<String> nonRetryableClasses =
-            Stream.of(dynamicNonRetryableClassesList, properties.getNonRetryableClasses())
+        List<String> retryableClasses =
+            Stream.of(dynamicRetraybleClassesList, properties.getRetryableClasses())
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
 
-        retryable = !nonRetryableClasses.contains(e.getClass().getName());
+        retryable = retryableClasses.contains(e.getClass().getName());
       } else {
-        retryable = !properties.getNonRetryableClasses().contains(e.getClass().getName());
+        retryable = properties.getRetryableClasses().contains(e.getClass().getName());
       }
     } catch (Exception caughtException) {
       log.error("Unexpected exception while processing retryable classes", caughtException);


### PR DESCRIPTION
…(#4097)

The pattern of opting-out of non-SpinnakerExceptions is too broad and results in retries that quickly spiral out of control.  Until we have wide spread adoption of SpinnakerException and can make all of our retryable decisions off that, we will specifically opt-in to retrying exceptions.

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
